### PR TITLE
CORS for all, wind type input

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ $ npm start
 
 The following environment variables can be used to customize behaviour:
 
-| Variable   | Description                             | Default | Options     |
-|------------|-----------------------------------------|---------|-------------|
-| PORT       | The port the server will listen on      | 7000    | Port number |
-| RESOLUTION | Requested GFS data resolution           | 0.5     | 0.5, 1      |
-| WIND       | Enable the download of wind data        | true    | true, false |
-| TEMP       | Enable the download of temperature data | false   | true, false |
+| Variable   | Description                             | Default               | Options     |
+|------------|-----------------------------------------|-----------------------|-------------|
+| PORT       | The port the server will listen on      | 7000                  | Port number |
+| RESOLUTION | Requested GFS data resolution           | 0.5                   | 0.5, 1      |
+| WIND       | Enable the download of wind data        | true                  | true, false |
+| TEMP       | Enable the download of temperature data | false                 | true, false |
+| DATA       | Set Wind Data Type                      | lev_10_m_above_ground | data type   |
 
 ## Endpoints
 

--- a/index.js
+++ b/index.js
@@ -178,7 +178,7 @@ function getGribData(targetMoment, offset) {
       var_TMP: "on",
     },
     ...wind && {
-      lev_20_mb: "on",
+      lev_70_mb: "on",
       var_UGRD: "on",
       var_VGRD: "on",
     },

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const app = express();
 const grib2json = process.env.GRIB2JSON || "./converter/bin/grib2json";
 const port = process.env.PORT || 7000;
 const resolution = process.env.RESOLUTION || "0.5";
+const data = process.env.DATA || "lev_10_m_above_ground";
 const baseDir = `https://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_${resolution === "1" ? "1p00" : "0p50"}.pl`;
 const wind = process.env.WIND || true;
 const temp = process.env.TEMP || false;
@@ -162,7 +163,7 @@ function getGribData(targetMoment, offset) {
       var_TMP: "on",
     },
     ...wind && {
-      lev_70_mb: "on",
+      [data]: "on",
       var_UGRD: "on",
       var_VGRD: "on",
     },

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ const whitelist = [
   "http://localhost:8080",
   "http://localhost:3000",
   "http://localhost:4000",
+  "http://localhost:5000",
 ];
 
 const corsOptions = {

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ const corsOptions = {
 };
 
 app.use(compression());
-app.listen(port, () => {
+app.listen(port, '0.0.0.0', () => {
   console.log(`Running wind server for data resolution of ${resolution === "1" ? "1" : "0.5"} degree on port ${port}`);
 });
 

--- a/index.js
+++ b/index.js
@@ -26,32 +26,16 @@ const GFS_CYCLE_MAX_D = process.env.MAX_HISTORY_DAYS || 2;
 // Number of forecast hours to download for each model cycle
 const GFS_FORECAST_MAX_H = process.env.MAX_FORECAST_HOURS || 18;
 
-
-// cors config
-const whitelist = [
-  "http://localhost:8080",
-  "http://localhost:3000",
-  "http://localhost:4000",
-  "http://localhost:5000",
-];
-
-const corsOptions = {
-  origin(origin, callback) {
-    const originIsWhitelisted = whitelist.indexOf(origin) !== -1;
-    callback(null, originIsWhitelisted);
-  },
-};
-
 app.use(compression());
 app.listen(port, '0.0.0.0', () => {
   console.log(`Running wind server for data resolution of ${resolution === "1" ? "1" : "0.5"} degree on port ${port}`);
 });
 
-app.get("/", cors(corsOptions), (req, res) => {
+app.get("/", cors(), (req, res) => {
   res.send("Wind server : go to /latest for last wind data.");
 });
 
-app.get("/alive", cors(corsOptions), (req, res) => {
+app.get("/alive", cors(), (req, res) => {
   res.send("Wind server is alive");
 });
 
@@ -92,7 +76,7 @@ function findNearest(targetMoment, limitHours = GFS_FORECAST_MAX_H, searchBackwa
   return false;
 }
 
-app.get("/latest", cors(corsOptions), (req, res, next) => {
+app.get("/latest", cors(), (req, res, next) => {
   const targetMoment = moment().utc();
   const filename = findNearest(targetMoment);
   if (!filename) {
@@ -107,7 +91,7 @@ app.get("/latest", cors(corsOptions), (req, res, next) => {
   });
 });
 
-app.get("/nearest", cors(corsOptions), (req, res, next) => {
+app.get("/nearest", cors(), (req, res, next) => {
   const { time } = req.query;
   const limit = req.query.limit || GFS_FORECAST_MAX_H;
 

--- a/index.js
+++ b/index.js
@@ -178,7 +178,7 @@ function getGribData(targetMoment, offset) {
       var_TMP: "on",
     },
     ...wind && {
-      lev_10_m_above_ground: "on",
+      lev_20_mb: "on",
       var_UGRD: "on",
       var_VGRD: "on",
     },


### PR DESCRIPTION
I have made some general improvements to be able to integrate this project with something I'm working on:

- CORS is now enabled for all clients which solves a **_lot_** of issues
- The wind data type can now be provided (view options [here](https://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_0p50.pl?dir=%2Fgfs.20210406%2F00%2Fatmos))
- Enable TCP support by setting IP to localhost (0.0.0.0)

Please test and let me know if anything needs updating.